### PR TITLE
Fix/hooks-comments

### DIFF
--- a/src/hooks/useDiscussionCategories.ts
+++ b/src/hooks/useDiscussionCategories.ts
@@ -2,18 +2,42 @@ import { DropdownOption } from "@create-figma-plugin/ui";
 import { JSX } from "preact";
 import { useState, useEffect } from "preact/hooks";
 
+type UseDiscussionCategoriesResult = {
+  /**
+   * ドロップダウン用のカテゴリオプションの配列
+   */
+  options: Array<DropdownOption>;
+  /**
+   * 現在選択されているカテゴリ
+   */
+  category: null | string;
+  /**
+   * カテゴリを設定する関数
+   */
+  setCategory: (category: null | string) => void;
+  /**
+   * カテゴリ名とカテゴリIDのマッピング
+   */
+  categoryMap: Record<string, string>;
+  /**
+   * カテゴリの変更を処理する関数
+   */
+  handleTagChange: (event: JSX.TargetedEvent<HTMLInputElement>) => void;
+};
 /**
  * useDiscussionCategories フック
  * 
  * GitHub Discussions のカテゴリを取得し、これらのカテゴリオプションおよび選択状態を管理します。
  * 
- * @return {Array<DropdownOption>} options - ドロップダウン用のカテゴリオプションの配列。
- * @return {null | string} category - 現在選択されているカテゴリ。
- * @return {function} setCategory - 現在選択されているカテゴリを設定する関数。
- * @return {Record<string, string>} categoryMap - カテゴリ名とカテゴリIDのマッピング。
- * @return {function} handleTagChange - カテゴリタグの変更を処理する関数。
+ * 
+ * @returns {UseDiscussionCategoriesResult} 結果オブジェクトには以下のプロパティが含まれます:
+ * - options: ドロップダウン用のカテゴリオプションの配列
+ * - category: 現在選択されているカテゴリ
+ * - setCategory: 現在選択されているカテゴリを設定する関数
+ * - categoryMap: カテゴリ名とカテゴリIDのマッピング
+ * - handleTagChange: カテゴリタグの変更を処理する関数
  */
-export function useDiscussionCategories() {
+export function useDiscussionCategories(): UseDiscussionCategoriesResult {
   const [options, setOptions] = useState<Array<DropdownOption>>([]);
   const [category, setCategory] = useState<null | string>(null);
   const [categoryMap, setCategoryMap] = useState<Record<string, string>>({});
@@ -49,5 +73,6 @@ export function useDiscussionCategories() {
       window.removeEventListener("message", handleMessage);
     };
   }, []);
+
   return { options, category, setCategory, categoryMap, handleTagChange };
 }

--- a/src/hooks/useDiscussionCategories.ts
+++ b/src/hooks/useDiscussionCategories.ts
@@ -24,6 +24,7 @@ type UseDiscussionCategoriesResult = {
    */
   handleTagChange: (event: JSX.TargetedEvent<HTMLInputElement>) => void;
 };
+
 /**
  * useDiscussionCategories フック
  * 

--- a/src/hooks/useDiscussionLabels.ts
+++ b/src/hooks/useDiscussionLabels.ts
@@ -44,7 +44,7 @@ type UseDiscussionLabelsResult = {
  *
  * GitHub Discussions のラベルを取得し、選択状態やロード状態を管理します。
  *
- * @returns {UseDiscussionLabelsResult} 結果オブジェクトには以下のプロパティが含まれます
+ * @returns {UseDiscussionLabelsResult} 結果オブジェクトには以下のプロパティが含まれます:
  * - isLoadingLabels: ラベルのロード状態
  * - labelMap: ラベル名とラベルIDのマッピング
  * - labelOptions: ラベルオプション

--- a/src/hooks/useDiscussionLabels.ts
+++ b/src/hooks/useDiscussionLabels.ts
@@ -8,28 +8,60 @@ import {
 } from "@create-figma-plugin/ui";
 import { useState, useEffect } from "preact/hooks";
 
+type UseDiscussionLabelsResult = {
+  /**
+   * ラベルのロード状態
+   */
+  isLoadingLabels: boolean;
+  /**
+   * ラベル名とラベルIDのマッピング
+   */
+  labelMap: Record<string, string>;
+  /**
+   * ラベルオプション
+   */
+  labelOptions: Array<RadioButtonsOption>;
+  /**
+   * セグメントコントロールの選択状態
+   */
+  segmentedControlValues: string[];
+  /**
+   * セグメントコントロールの選択状態を更新する関数
+   */
+  setSegmentedControlValues: (values: string[]) => void;
+  /**
+   * セグメントコントロール用のオプション
+   */
+  segmentedControlOptions: Array<SegmentedControlOption>;
+  /**
+   * セグメントコントロールの選択変更を処理する関数
+   */
+  createHandleChangeSegmentedControl: (index: number) => (event: Event) => void;
+};
+
 /**
  * useDiscussionLabels フック
  *
  * GitHub Discussions のラベルを取得し、選択状態やロード状態を管理します。
  *
- * @return {boolean} isLoadingLabels - ラベルのロード状態。
- * @return {Record<string, string>} labelMap - ラベル名とラベルIDのマッピング。
- * @return {Array<SegmentedControlOption>} segmentedControlOptions - セグメントコントロール用のオプション。
- * @return {Array<string>} segmentedControlValues - セグメントコントロールの選択状態。
- * @return {function} setSegmentedControlValues - セグメントコントロールの選択状態を更新する関数。
- * @return {Array<RadioButtonsOption>} labelOptions - ラベルオプション。
- * @return {function} createHandleChangeSegmentedControl - セグメントコントロールの選択変更を処理する関数。
-*/
-export function useDiscussionLabels() {
+ * @returns {UseDiscussionLabelsResult} 結果オブジェクトには以下のプロパティが含まれます
+ * - isLoadingLabels: ラベルのロード状態
+ * - labelMap: ラベル名とラベルIDのマッピング
+ * - labelOptions: ラベルオプション
+ * - segmentedControlValues: セグメントコントロールの選択状態
+ * - setSegmentedControlValues: セグメントコントロールの選択状態を更新する関数
+ * - segmentedControlOptions: セグメントコントロール用のオプション
+ * - createHandleChangeSegmentedControl: セグメントコントロールの選択変更を処理する関数
+ */
+export function useDiscussionLabels(): UseDiscussionLabelsResult {
+  const [isLoadingLabels, setIsLoadingLabels] = useState<boolean>(true);
+  const [labelMap, setLabelMap] = useState<Record<string, string>>({});
   const [labelOptions, setLabelOptions] = useState<Array<RadioButtonsOption>>(
     []
   );
   const [segmentedControlValues, setSegmentedControlValues] = useState<
     string[]
   >([]);
-  const [labelMap, setLabelMap] = useState<Record<string, string>>({});
-  const [isLoadingLabels, setIsLoadingLabels] = useState<boolean>(true);
   const segmentedControlOptions: Array<SegmentedControlOption> = [
     {
       children: h(IconOptionDisabled16, null),
@@ -42,14 +74,14 @@ export function useDiscussionLabels() {
   ];
 
   /**
-   * セグメントコントロールの選択変更を処理する関数を作成
+   * セグメントコントロールの選択変更を処理する関数
    *
    * @param {number} index - セグメントコントロールのインデックス
    * @return {function} - イベントリスナー関数を返す
    */
   function createHandleChangeSegmentedControl(index: number) {
     return (event: Event) => {
-      const newValue = (event as any).currentTarget.value; // 型キャスト
+      const newValue = (event as any).currentTarget.value;
       setSegmentedControlValues((prevValues) => {
         const newValues = [...prevValues];
         newValues[index] = newValue;

--- a/src/hooks/useElementName.ts
+++ b/src/hooks/useElementName.ts
@@ -1,5 +1,20 @@
 import { useState, useEffect } from "preact/hooks";
 
+type UseElementNameResult = {
+  /**
+   * 現在選択されている要素の名前
+   */
+  elementName: string | null;
+  /**
+   * 要素名を更新する関数
+   */
+  setElementName: (elementName: string) => void;
+  /**
+   * 生成されたURL
+   */
+  generatedUrl: string | null;
+};
+
 /**
  * useElementName フック
  *
@@ -7,11 +22,12 @@ import { useState, useEffect } from "preact/hooks";
  * 要素が選択されたときに要素名を更新し、対応する URL を生成します。
  * 要素が選択解除されたときには、要素名と生成された URL を初期化します。
  *
- * @return {string | null} elementName - 現在選択されている要素の名前。
- * @return {function} setElementName - 要素名を更新するための関数。
- * @return {string | null} generatedUrl - 選択された要素の対応URL。
+ * @returns {UseElementNameResult} 結果オブジェクトには以下のプロパティが含まれます:
+ * - elementName: 現在選択されている要素の名前
+ * - setElementName: 要素名を更新する関数
+ * - generatedUrl: 生成されたURL
  */
-export function useElementName() {
+export function useElementName(): UseElementNameResult {
   const [elementName, setElementName] = useState<null | string>(
     "Discussion Select the element you want to discuss"
   );

--- a/src/hooks/useFormState.ts
+++ b/src/hooks/useFormState.ts
@@ -1,6 +1,33 @@
 import { JSX } from "preact";
 import { useState } from "preact/hooks";
 
+type UseFormStateResult = {
+  /**
+   * 現在のタイトルの値
+   */
+  title: string;
+  /**
+   * タイトル値を更新する関数
+   */
+  setTitle: (title: string) => void;
+  /**
+   * 現在の本文の値
+   */
+  body: string;
+  /**
+   * 本文値を更新する関数
+   */
+  setBody: (body: string) => void;
+  /**
+   * タイトルの入力変更を処理する関数
+   */
+  handleInputTitle: (event: JSX.TargetedEvent<HTMLInputElement>) => void;
+  /**
+   * 本文の入力変更を処理する関数
+   */
+  handleInputBody: (event: JSX.TargetedEvent<HTMLTextAreaElement>) => void;
+}
+
 /**
  * useFormState フック
  * 
@@ -9,14 +36,15 @@ import { useState } from "preact/hooks";
  * 
  * @param {string} [initialTitle=""] - タイトルの初期値。
  * @param {string} [initialBody=""] - 本文の初期値。
- * @return {string} title - 現在のタイトルの値。
- * @return {function} setTitle - タイトル値を更新する関数。
- * @return {string} body - 現在の本文の値。
- * @return {function} setBody - 本文値を更新する関数。
- * @return {function} handleInputTitle - タイトルの入力変更を処理する関数。
- * @return {function} handleInputBody - 本文の入力変更を処理する関数。
+ * @returns {UseFormStateResult} 結果オブジェクトには以下のプロパティが含まれます:
+ * - title: 現在のタイトルの値
+ * - setTitle: タイトル値を更新する関数
+ * - body: 現在の本文の値
+ * - setBody: 本文値を更新する関数
+ * - handleInputTitle: タイトルの入力変更を処理する関数
+ * - handleInputBody: 本文の入力変更を処理する関数
  */
-export function useFormState(initialTitle: string = "", initialBody: string = "") {
+export function useFormState(initialTitle: string = "", initialBody: string = ""): UseFormStateResult {
   // タイトルの状態を管理
   const [title, setTitle] = useState<string>(initialTitle);
   

--- a/src/hooks/useHandleClick.ts
+++ b/src/hooks/useHandleClick.ts
@@ -1,5 +1,12 @@
 import { JSX } from "preact";
 
+type UseHandleClickResult = {
+  /**
+   * クリックイベントを処理する関数
+   */
+  handleClick: (event: JSX.TargetedMouseEvent<HTMLButtonElement>) => void;
+};
+
 /**
  * useHandleClick フック
  *
@@ -27,7 +34,8 @@ import { JSX } from "preact";
  * @param {function} dependencies.setCategory - カテゴリを設定する関数。
  * @param {function} dependencies.setSegmentedControlValues - セグメントコントロールの選択状態を更新する関数。
  *
- * @return {function} handleClick - クリックイベントを処理する関数。
+ * @returns {UseHandleClickResult} 結果オブジェクトには以下のプロパティが含まれます:
+ * - handleClick: クリックイベントを処理する関数
  */
 export function useHandleClick(dependencies: {
   elementName: string | null;
@@ -49,7 +57,7 @@ export function useHandleClick(dependencies: {
   setBody: (body: string) => void;
   setCategory: (category: string | null) => void;
   setSegmentedControlValues: (values: string[]) => void;
-}) {
+}): UseHandleClickResult {
   const {
     elementName,
     setElementName,

--- a/src/hooks/useImageUpload.ts
+++ b/src/hooks/useImageUpload.ts
@@ -1,17 +1,37 @@
 import { useState } from "preact/hooks";
 
+type UseImageUploadResult = {
+  /**
+   * 現在選択されているファイルの配列
+   */
+  selectedFiles: Array<File>;
+  /**
+   * 選択されているファイルの配列を更新する関数
+   */
+  setSelectedFiles: (files: Array<File>) => void;
+  /**
+   * ファイルを base64 文字列へと変換する関数
+   */
+  fileToBase64: (file: File) => Promise<string>;
+  /**
+   * 選択されたファイルを処理し、状態を更新する関数
+   */
+  handleSelectedFiles: (files: Array<File>) => void;
+};
+
 /**
  * useImageUpload フック
  * 
  * 画像アップロードを管理するためのカスタムフックです。
  * 選択されたファイルを管理し、ファイルを base64 エンコードに変換します。
  * 
- * @return {Array<File>} selectedFiles - 現在選択されているファイルの配列。
- * @return {function} setSelectedFiles - 選択されているファイルの配列を更新する関数。
- * @return {function} fileToBase64 - ファイルを base64 文字列へと変換する関数。
- * @return {function} handleSelectedFiles - 選択されたファイルを処理し、状態を更新する関数。
+ * @returns {UseImageUploadResult} 結果オブジェクトには以下のプロパティが含まれます:
+ * - selectedFiles: 現在選択されているファイルの配列
+ * - setSelectedFiles: 選択されているファイルの配列を更新する関数
+ * - fileToBase64: ファイルを base64 文字列へと変換する関数
+ * - handleSelectedFiles: 選択されたファイルを処理し、状態を更新する関数
  */
-export function useImageUpload() {
+export function useImageUpload(): UseImageUploadResult {
   const [selectedFiles, setSelectedFiles] = useState<Array<File>>([]);
 
   /**

--- a/src/hooks/useScrollDetection.ts
+++ b/src/hooks/useScrollDetection.ts
@@ -1,5 +1,17 @@
 import { DropdownOption, RadioButtonsOption } from "@create-figma-plugin/ui";
+import { RefObject } from "preact";
 import { useEffect, useRef, useState } from "preact/hooks";
+
+type UseScrollDetectionDependenciesResult = {
+  /**
+   * スクロール可能なコンテンツの参照
+   */
+  contentRef: RefObject<HTMLDivElement>;
+  /**
+   * コンテンツがスクロール可能かどうかを示すフラグ
+   */
+  needsScroll: boolean;
+}
 
 /**
  * useScrollDetection フック
@@ -8,8 +20,9 @@ import { useEffect, useRef, useState } from "preact/hooks";
  * 指定された依存関係が変化したときに、コンテンツがスクロール可能かどうかをチェックします。
  * @param {object} dependencies - フックが再評価されるトリガーとなる依存関係のオブジェクト。
  * 
- * @return {RefObject<HTMLDivElement>} contentRef - スクロール可能なコンテンツの参照。
- * @return {boolean} needsScroll - コンテンツがスクロール可能かどうかを示すフラグ。
+ * @returns {UseScrollDetectionDependenciesResult} 結果オブジェクトには以下のプロパティが含まれます:
+ * - contentRef: スクロール可能なコンテンツの参照
+ * - needsScroll: コンテンツがスクロール可能かどうかを示すフラグ
  */
 export function useScrollDetection(dependencies: {
   options: Array<DropdownOption>;
@@ -19,7 +32,7 @@ export function useScrollDetection(dependencies: {
   category: string | null;
   body: string;
   isLoadingLabels: boolean;
-}) {
+}): UseScrollDetectionDependenciesResult {
   const {
     options,
     labelOptions,
@@ -29,10 +42,7 @@ export function useScrollDetection(dependencies: {
     body,
     isLoadingLabels,
   } = dependencies;
-  // スクロール可能なコンテンツの参照
   const contentRef = useRef<HTMLDivElement>(null);
-
-  // コンテンツがスクロール可能かどうかを示すフラグ
   const [needsScroll, setNeedsScroll] = useState(false);
 
   // 依存関係が変化したときにスクロールの必要性をチェックする副作用フック


### PR DESCRIPTION
各フック関数が返す値の型を作成し、より明確にするためにそれぞれの関数に設定しました。

変更箇所:
1. useDiscussionCategories フック - 型 UseDiscussionCategoriesResult を作成。
2. useDiscussionLabels フック - 型 UseDiscussionLabelsResult を作成。
3. useElementName フック - 型 UseElementNameResult を作成。
4. useFormState フック - 型 UseFormStateResult を作成。
5. useHandleClick フック - 型 UseHandleClickResult を作成。
6. useImageUpload フック - 型 UseImageUploadResult を作成。
7. useScrollDetection フック - 型 UseScrollDetectionDependenciesResult を作成。
8. 適宜不要コメントを削除

それぞれの型については、関数の返り値に合わせて詳細に定義し、各プロパティがどのような役割を持つかをコメントで明示しています。